### PR TITLE
HPE Public keys updated with Pelican client 7.17.2

### DIFF
--- a/fdp-hpe1/oauth2/keys
+++ b/fdp-hpe1/oauth2/keys
@@ -1,12 +1,11 @@
 {
-    "keys": [
-        {
-            "alg": "RS256",
-            "e": "AQAB",
-            "kid": "d104",
-            "kty": "RSA",
-            "n": "vrAHDiqmmAzuSx4hbRolG0pT4NLpEm5XVjOAnuYBhcHw6Nq70V14wGFI7m3j8fQZroGTgGXs2leZhT5gIUmwoiOpZIHSAWVfTWaD7V2Kku0gn-0cDEb2nV8NVgLG2-IRT9qNVlUVBcrYBjdjlF6yPktUjQ0fIQaNlntN1MNROHQLUZR0J61dC_Dtq67Jlsqq61QKZQ9SukMpCIA4b-RuBh6aTaRT7JsBO_QO1oHp6Ea3oTulsXFn8s2cPRTWlzC3X-JZ9o2Q4mEz45tIJp1SPdTm2iIesdYQbQLVWrYkJt-_ZN6FqngS6xYeUCPwU-j27deJgTxp0WyC1-aE1GwlTQ==",
-            "use": "sig"
-        }
-    ]
+        "keys": [
+                {
+                        "alg": "ES256",
+                        "e": "AQAB",
+                        "kid": "UwxCeasfR8-DMjvzBteGM9QU93eK1WJ_iqCf2Zc4Om4",
+                        "kty": "RSA",
+                        "n": "vrAHDiqmmAzuSx4hbRolG0pT4NLpEm5XVjOAnuYBhcHw6Nq70V14wGFI7m3j8fQZroGTgGXs2leZhT5gIUmwoiOpZIHSAWVfTWaD7V2Kku0gn-0cDEb2nV8NVgLG2-IRT9qNVlUVBcrYBjdjlF6yPktUjQ0fIQaNlntN1MNROHQLUZR0J61dC_Dtq67Jlsqq61QKZQ9SukMpCIA4b-RuBh6aTaRT7JsBO_QO1oHp6Ea3oTulsXFn8s2cPRTWlzC3X-JZ9o2Q4mEz45tIJp1SPdTm2iIesdYQbQLVWrYkJt-_ZN6FqngS6xYeUCPwU-j27deJgTxp0WyC1-aE1GwlTQ"
+                }
+        ]
 }

--- a/fdp-hpe2/oauth2/keys
+++ b/fdp-hpe2/oauth2/keys
@@ -1,13 +1,11 @@
 {
-    "keys": [
-        {
-            "alg": "RS256",
-            "e": "AQAB",
-            "kid": "12ec",
-            "kty": "RSA",
-            "n": "n6DmDGA8C12838_nCMRqGEKCKp6ZvpVUsMgUTWWpxil4jPLal-0PQRNffTjqmnjAwXGuGkZ0hGMERvlfyljfcy4vY2Vad95hIptMIeLMPKcBUMAk5aBM3RqAUh-8vaKeRQUmfMHqYKS-exUJEmCP-y8f2q3kysCuX8v-onWx3qyT79U2Fm4TPGJDZF_8De975RU5KQJ4dm43IQ3Ab4XqISki9ZZQ3axwMpz5IUVryB-CC7BO4EwWM94vyWt_0vsXlbBD5kuFSb6i2st1HQJ2i-LB2LmjSrycWlnEUdORMMWT-HgU91-ODBPYGNrIkCFvGC95PQ_g8H3y7WKK--x91w==",
-            "use": "sig"
-        }
-    ]
+        "keys": [
+                {
+                        "alg": "ES256",
+                        "e": "AQAB",
+                        "kid": "_4wHO5VeLpXBu8zJ0hZfbr8xYIV3Tc5WWbH3rPvbMAs",
+                        "kty": "RSA",
+                        "n": "n6DmDGA8C12838_nCMRqGEKCKp6ZvpVUsMgUTWWpxil4jPLal-0PQRNffTjqmnjAwXGuGkZ0hGMERvlfyljfcy4vY2Vad95hIptMIeLMPKcBUMAk5aBM3RqAUh-8vaKeRQUmfMHqYKS-exUJEmCP-y8f2q3kysCuX8v-onWx3qyT79U2Fm4TPGJDZF_8De975RU5KQJ4dm43IQ3Ab4XqISki9ZZQ3axwMpz5IUVryB-CC7BO4EwWM94vyWt_0vsXlbBD5kuFSb6i2st1HQJ2i-LB2LmjSrycWlnEUdORMMWT-HgU91-ODBPYGNrIkCFvGC95PQ_g8H3y7WKK--x91w"
+                }
+        ]
 }
-

--- a/fdp-hpe3/oauth2/keys
+++ b/fdp-hpe3/oauth2/keys
@@ -1,13 +1,11 @@
 {
-    "keys": [
-        {
-            "alg": "RS256",
-            "e": "AQAB",
-            "kid": "cb23",
-            "kty": "RSA",
-            "n": "xfnIMSSzNcqjMda7L6Ki-JPdZXsDEL6o8Fjqex3q9KsUGWOBLwdZj_BP4kVwKxze69hFctTxz6f4dGqVwso9djbBLWRyQ_4DYycBPDwchTJXW8kxCJ6-wWEN9qn2vSj6jb6FPmu7A_COZOxadgvZ0yjAfe3IF0CYLUEgCl3lWiGh4Ex5qLJCVUhzIzY76KW-1PuJ7zPhEd2OlC7PsdyHScp3oMDjAkEff6scCZM1xRh5yQuS0M-iEU8iWRJhzDTK4_2d11GB3hT_s2VFs_wCngA-7vMyIGlS_A4Jg5Yv_-jbJxzSAwD55JxAwIyr-HwBqFAMIKsoedwVCF550T_amw==",
-            "use": "sig"
-        }
-    ]
+        "keys": [
+                {
+                        "alg": "ES256",
+                        "e": "AQAB",
+                        "kid": "QkT2Bp-RvI9FIls1bI0G4_R5FXZ-HWHgzcDK_e-Tff8",
+                        "kty": "RSA",
+                        "n": "xfnIMSSzNcqjMda7L6Ki-JPdZXsDEL6o8Fjqex3q9KsUGWOBLwdZj_BP4kVwKxze69hFctTxz6f4dGqVwso9djbBLWRyQ_4DYycBPDwchTJXW8kxCJ6-wWEN9qn2vSj6jb6FPmu7A_COZOxadgvZ0yjAfe3IF0CYLUEgCl3lWiGh4Ex5qLJCVUhzIzY76KW-1PuJ7zPhEd2OlC7PsdyHScp3oMDjAkEff6scCZM1xRh5yQuS0M-iEU8iWRJhzDTK4_2d11GB3hT_s2VFs_wCngA-7vMyIGlS_A4Jg5Yv_-jbJxzSAwD55JxAwIyr-HwBqFAMIKsoedwVCF550T_amw"
+                }
+        ]
 }
-

--- a/fdp-hpe4/oauth2/keys
+++ b/fdp-hpe4/oauth2/keys
@@ -1,13 +1,11 @@
 {
-    "keys": [
-        {
-            "alg": "RS256",
-            "e": "AQAB",
-            "kid": "b32c",
-            "kty": "RSA",
-            "n": "xOLdOLXejcUf-59bbk99ubZYjUqS0OytmMFgSpvoAMp6NyPEQlhGOBv3rpZP5JvUO85SC8dVLy_9ny0yrWpI7dvhl2rkdMJKbtP1KxNlGIYwE6bp5wc4BtM5q88qKrqOe9agEXP5WDhMvCXmcPiVz0b3etauxXRS3JRieopevpTTEBxPBo_cGOpH3VE7UgZmJrqLI7KNJ0-298I2kHkqwi0Pw9qiViXHw9PeLlrKCKOx1mg7EwNa6Vt_zzFJpvN8M_QsJX8Chv-nroSfmqMMD5kqyPEUOyCAyKvkZLCihZlnN4dsYKGbah4OSl4UvgJK1VSodIZwW5uJWqLpL1OStQ==",
-            "use": "sig"
-        }
-    ]
+        "keys": [
+                {
+                        "alg": "ES256",
+                        "e": "AQAB",
+                        "kid": "mG7wQfCKTiPqUiRA-K_FbXZiIwqSu9Lj9Jk1pOnH42Q",
+                        "kty": "RSA",
+                        "n": "xOLdOLXejcUf-59bbk99ubZYjUqS0OytmMFgSpvoAMp6NyPEQlhGOBv3rpZP5JvUO85SC8dVLy_9ny0yrWpI7dvhl2rkdMJKbtP1KxNlGIYwE6bp5wc4BtM5q88qKrqOe9agEXP5WDhMvCXmcPiVz0b3etauxXRS3JRieopevpTTEBxPBo_cGOpH3VE7UgZmJrqLI7KNJ0-298I2kHkqwi0Pw9qiViXHw9PeLlrKCKOx1mg7EwNa6Vt_zzFJpvN8M_QsJX8Chv-nroSfmqMMD5kqyPEUOyCAyKvkZLCihZlnN4dsYKGbah4OSl4UvgJK1VSodIZwW5uJWqLpL1OStQ"
+                }
+        ]
 }
-


### PR DESCRIPTION
Keys updated with Pelican client 7.17.2
```
$ pelican key create --private-key hpe1-private.pem --public-key hpe1_public.key
Successfully generated keys at:
Private key: hpe1-private.pem
Public Key: hpe1_public.key
```
